### PR TITLE
feat: Add prompt quality signals and cost tracking

### DIFF
--- a/.ralph/prd.json
+++ b/.ralph/prd.json
@@ -15,7 +15,7 @@
         "cargo fmt --check && cargo clippy && cargo test passes"
       ],
       "priority": 1,
-      "passes": false,
+      "passes": true,
       "notes": "Modify src/bottlenecks.rs. When detecting a bottleneck, look backwards through messages to find the preceding 'user' type message. Store first 200 chars."
     },
     {

--- a/.ralph/prd.json
+++ b/.ralph/prd.json
@@ -61,7 +61,7 @@
         "cargo fmt --check && cargo clippy && cargo test passes"
       ],
       "priority": 4,
-      "passes": false,
+      "passes": true,
       "notes": "Create src/cost.rs. Load all sessions, sum token counts, calculate cost. Format similar to report output with colored numbers."
     },
     {

--- a/.ralph/prd.json
+++ b/.ralph/prd.json
@@ -1,69 +1,83 @@
 {
   "project": "ai-session-tracker",
-  "branchName": "ralph/github-integration",
-  "description": "Add GitHub integration to track time per issue by linking PRs to Claude sessions",
+  "branchName": "feature/issue-19-prompt-quality-cost",
+  "description": "Add prompt quality signals and cost tracking to help users understand what prompts lead to bottlenecks and track API costs",
   "userStories": [
     {
       "id": "US-001",
-      "title": "GitHub sync command",
-      "description": "Add `aist sync` command that fetches merged PRs from GitHub and caches PR→Issue→Branch mappings",
+      "title": "Extract prompts before bottlenecks",
+      "description": "Parse and store the user message that preceded each detected bottleneck",
       "acceptanceCriteria": [
-        "aist sync fetches merged PRs using `gh pr list --state merged`",
-        "Extracts branch name and closed issues from each PR",
-        "Caches data in ~/.config/aist/repos/{owner}-{repo}.json",
-        "Shows progress during sync (X PRs fetched)",
-        "Auto-detects repo from git remote if not specified",
+        "Bottleneck struct includes optional `preceding_prompt: Option<String>` field",
+        "detect_bottlenecks extracts the last user message before each bottleneck",
+        "Prompt text is truncated to 200 chars if longer",
+        "Existing bottleneck detection logic unchanged",
         "cargo fmt --check && cargo clippy && cargo test passes"
       ],
       "priority": 1,
-      "passes": true,
-      "notes": "Create src/github.rs. Use std::process::Command to call `gh pr list --json number,headRefName,body,mergedAt,title --state merged`. Parse 'Closes #N' from PR body. Store in JSON file."
+      "passes": false,
+      "notes": "Modify src/bottlenecks.rs. When detecting a bottleneck, look backwards through messages to find the preceding 'user' type message. Store first 200 chars."
     },
     {
       "id": "US-002",
-      "title": "Issue list command",
-      "description": "Add `aist issues` command that shows time spent per GitHub issue",
+      "title": "Show prompts flag for bottlenecks command",
+      "description": "Add --show-prompts flag to bottlenecks command that displays the prompt before each bottleneck",
       "acceptanceCriteria": [
-        "aist issues lists issues with time metrics",
-        "Links sessions to issues via PR branch names",
-        "Shows: issue number, title, total time, session count",
-        "Sorted by total time descending",
-        "Shows total time across all issues",
+        "aist bottlenecks --show-prompts shows prompt before each bottleneck",
+        "Prompt displayed in dimmed/italic style below bottleneck",
+        "Default behavior (no flag) unchanged",
+        "Handles missing prompts gracefully (shows 'No prompt found')",
         "cargo fmt --check && cargo clippy && cargo test passes"
       ],
       "priority": 2,
-      "passes": true,
-      "notes": "Create src/issues.rs. Load GitHub cache, match sessions by gitBranch field. Sum duration from matching sessions. Format similar to bottlenecks output."
+      "passes": false,
+      "notes": "Modify src/main.rs to add --show-prompts flag. Update display_bottlenecks in bottlenecks.rs to optionally show prompts."
     },
     {
       "id": "US-003",
-      "title": "Issue detail command",
-      "description": "Add `aist issue <N>` command that shows detailed metrics for a specific issue",
+      "title": "Parse token usage from transcripts",
+      "description": "Extract input/output token counts from Claude transcript messages",
       "acceptanceCriteria": [
-        "aist issue 4 shows details for issue #4",
-        "Shows: status, branch, total time, session count",
-        "Lists individual sessions with timestamps and duration",
-        "Shows time breakdown by activity type (productive, reading, etc)",
+        "Session struct includes token_input and token_output fields",
+        "Parser extracts tokens from message metadata if present",
+        "Aggregates tokens across all messages in session",
+        "Handles missing token data (defaults to 0)",
         "cargo fmt --check && cargo clippy && cargo test passes"
       ],
       "priority": 3,
-      "passes": true,
-      "notes": "Add to src/issues.rs. Reuse flamegraph::extract_spans for activity breakdown. Format similar to timeline output."
+      "passes": false,
+      "notes": "Modify src/parser.rs. Claude transcripts have 'usage' field with input_tokens and output_tokens in assistant messages. Check actual transcript format first."
     },
     {
       "id": "US-004",
-      "title": "Flamegraph by issue",
-      "description": "Add --group-by issue option to flamegraph command",
+      "title": "Cost command",
+      "description": "Add `aist cost` command that shows token usage and estimated API cost",
       "acceptanceCriteria": [
-        "aist flame --group-by issue generates SVG grouped by issue",
-        "Each row shows an issue with time breakdown",
-        "Color-coded by activity type",
-        "Sorted by total time descending",
+        "aist cost shows total tokens and estimated cost",
+        "Breaks down by input vs output tokens",
+        "Shows cost per session if --detailed flag",
+        "Supports --period filter (day, week, month, all)",
+        "Uses Claude pricing: $15/M input, $75/M output tokens",
         "cargo fmt --check && cargo clippy && cargo test passes"
       ],
       "priority": 4,
-      "passes": true,
-      "notes": "Add generate_svg_by_issue to src/flamegraph.rs. Similar pattern to generate_svg_by_project but group by issue number instead."
+      "passes": false,
+      "notes": "Create src/cost.rs. Load all sessions, sum token counts, calculate cost. Format similar to report output with colored numbers."
+    },
+    {
+      "id": "US-005",
+      "title": "Cost per PR/Issue",
+      "description": "Show cost breakdown per PR and issue in existing commands",
+      "acceptanceCriteria": [
+        "aist prs shows cost column",
+        "aist issues shows cost column",
+        "aist pr <N> shows total cost for that PR",
+        "aist issue <N> shows total cost for that issue",
+        "cargo fmt --check && cargo clippy && cargo test passes"
+      ],
+      "priority": 5,
+      "passes": false,
+      "notes": "Modify src/prs.rs and src/issues.rs to include cost calculations. Reuse token parsing from US-003."
     }
   ]
 }

--- a/.ralph/prd.json
+++ b/.ralph/prd.json
@@ -76,7 +76,7 @@
         "cargo fmt --check && cargo clippy && cargo test passes"
       ],
       "priority": 5,
-      "passes": false,
+      "passes": true,
       "notes": "Modify src/prs.rs and src/issues.rs to include cost calculations. Reuse token parsing from US-003."
     }
   ]

--- a/.ralph/prd.json
+++ b/.ralph/prd.json
@@ -45,7 +45,7 @@
         "cargo fmt --check && cargo clippy && cargo test passes"
       ],
       "priority": 3,
-      "passes": false,
+      "passes": true,
       "notes": "Modify src/parser.rs. Claude transcripts have 'usage' field with input_tokens and output_tokens in assistant messages. Check actual transcript format first."
     },
     {

--- a/.ralph/prd.json
+++ b/.ralph/prd.json
@@ -30,7 +30,7 @@
         "cargo fmt --check && cargo clippy && cargo test passes"
       ],
       "priority": 2,
-      "passes": false,
+      "passes": true,
       "notes": "Modify src/main.rs to add --show-prompts flag. Update display_bottlenecks in bottlenecks.rs to optionally show prompts."
     },
     {

--- a/.ralph/progress.txt
+++ b/.ralph/progress.txt
@@ -64,5 +64,39 @@ Started: 2026-01-13
 - Pattern: Cache reads are discounted (usually free), cache creation counts toward input
 - Gotcha: Only assistant messages have usage data, not user messages
 - Pattern: Claude Opus pricing: $15/M input, $75/M output tokens
+- Pattern: Use calculate_cost() from cost.rs for consistent pricing across commands
+- Pattern: Add text_content to Message for capturing user prompts
+- Pattern: preceding_prompt links bottlenecks to the prompt that triggered them
+
+---
+
+## 2026-01-14 - Prompt Quality & Cost Tracking Feature
+
+### US-001: Extract prompts before bottlenecks
+- Added text_content field to Message struct
+- Added preceding_prompt field to all bottleneck structs
+- Implemented find_preceding_prompt helper to look backwards through messages
+- Prompts truncated to 200 chars
+
+### US-002: Show prompts flag for bottlenecks command
+- Added --show-prompts flag to `aist bottlenecks`
+- Displays prompt in dimmed italic style below each bottleneck
+
+### US-003: Parse token usage from transcripts
+- Added token_input and token_output fields to Session struct
+- Parse usage data from `message.usage` in assistant messages
+- Aggregates input_tokens + cache_creation_input_tokens as billable input
+
+### US-004: Cost command
+- Created src/cost.rs with calculate_cost() function
+- Added `aist cost` command with --period and --detailed flags
+- Shows total tokens, breakdown by input/output, and estimated cost
+
+### US-005: Cost per PR/Issue
+- Added cost column to `aist prs` and `aist issues` output
+- Added total cost to `aist pr <N>` and `aist issue <N>` detail views
+- Reused calculate_cost() for consistent pricing
+
+**Files changed:** src/parser.rs, src/bottlenecks.rs, src/cost.rs (new), src/main.rs, src/prs.rs, src/issues.rs
 
 ---

--- a/.ralph/progress.txt
+++ b/.ralph/progress.txt
@@ -56,3 +56,13 @@ Started: 2026-01-13
   - Same activity color scheme and proportional bars as generate_svg_by_project
   - Load GitHub cache at start, return clear error if not found
 ---
+
+## Codebase Patterns (Updated 2026-01-14)
+
+- Pattern: Token usage is in assistant messages under `message.usage`
+- Pattern: Fields: input_tokens, cache_creation_input_tokens, cache_read_input_tokens, output_tokens
+- Pattern: Cache reads are discounted (usually free), cache creation counts toward input
+- Gotcha: Only assistant messages have usage data, not user messages
+- Pattern: Claude Opus pricing: $15/M input, $75/M output tokens
+
+---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,9 @@ ai-session-tracker/
 │   ├── report.rs          # Generate reports
 │   ├── flamegraph.rs      # SVG flamegraph visualization
 │   ├── github.rs          # GitHub API (PR sync, caching)
-│   └── issues.rs          # Issue-level time tracking
+│   ├── issues.rs          # Issue-level time tracking
+│   ├── prs.rs             # PR-level time tracking
+│   └── export.rs          # HTML report generation
 └── product_research/      # Research scripts and findings
 ```
 
@@ -99,12 +101,19 @@ aist timeline         # Show latest session timeline
 aist list             # List recent sessions
 aist flame            # Generate flamegraph SVG
 aist flame --group-by project  # Group by project
-aist flame --group-by issue    # Group by GitHub issue
+aist flame --group-by pr       # Group by PR
 
 # GitHub Integration
 aist sync             # Fetch merged PRs, cache mappings
+aist prs              # List time per PR
+aist pr <N>           # Detailed breakdown for PR #N
 aist issues           # List time per issue
 aist issue <N>        # Detailed breakdown for issue #N
+
+# HTML Reports
+aist export           # Generate HTML report for current repo
+aist export --period week      # Filter by time period
+aist export -o report.html     # Custom output path
 ```
 
 ---
@@ -206,8 +215,11 @@ Tool results are in user messages:
 | `aist list` | List recent sessions | ✓ |
 | `aist flame` | Flamegraph SVG visualization | ✓ |
 | `aist sync` | Sync GitHub PRs and cache mappings | ✓ |
+| `aist prs` | List time spent per PR | ✓ |
+| `aist pr <N>` | Detailed breakdown for specific PR | ✓ |
 | `aist issues` | List time spent per GitHub issue | ✓ |
 | `aist issue <N>` | Detailed breakdown for specific issue | ✓ |
+| `aist export` | Generate HTML report with flamegraph | ✓ |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -50,20 +50,50 @@ aist flame --group-by issue     # Group by GitHub issue
 
 ### GitHub Integration
 
-Track time spent per GitHub issue by linking PRs to Claude sessions:
+Track time spent per GitHub issue and PR by linking to Claude sessions:
 
 ```bash
 # Sync merged PRs from GitHub (caches PR→Issue→Branch mappings)
 aist sync
+
+# List time spent per PR
+aist prs
+
+# Detailed breakdown for a specific PR
+aist pr 12
 
 # List time spent per issue
 aist issues
 
 # Detailed breakdown for a specific issue
 aist issue 4
+
+# Export HTML report for current repo
+aist export
+
+# Export with options
+aist export --period week --output my-report.html
 ```
 
-**How it works:** Sessions are linked to issues via branch names. When you work on a branch like `feature/issue-4-auth`, and your PR says "Closes #4", `aist` connects all sessions on that branch to issue #4.
+**How it works:** Sessions are linked to PRs/issues via branch names. When you work on a branch like `feature/issue-4-auth`, and your PR says "Closes #4", `aist` connects all sessions on that branch to that PR and issue #4.
+
+### HTML Reports
+
+Generate comprehensive reports with interactive flamegraphs:
+
+```bash
+aist export                    # Auto-detect repo from git remote
+aist export --period week      # Filter by time period
+aist export --owner X --repo Y # Specify repo explicitly
+```
+
+Reports include:
+- Summary stats (sessions, time, efficiency)
+- Time breakdown by activity type
+- Bottleneck analysis
+- PR breakdown table
+- Recommendations
+- Interactive flamegraph (hover for details)
 
 ## Example Output
 

--- a/report-rcatalan98-ai-session-tracker.html
+++ b/report-rcatalan98-ai-session-tracker.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AI Session Report - rcatalan98/ai-session-tracker</title>
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 2rem;
+            background: #f9fafb;
+        }
+        h1 { font-size: 2rem; color: #111; margin-bottom: 0.25rem; }
+        h2 { font-size: 1.25rem; color: #374151; margin: 2rem 0 1rem; border-bottom: 2px solid #e5e7eb; padding-bottom: 0.5rem; }
+        .subtitle { color: #6b7280; font-size: 1rem; margin-bottom: 0.5rem; }
+        .date-range { color: #9ca3af; font-size: 0.875rem; margin-bottom: 2rem; }
+        .card { background: white; border-radius: 8px; padding: 1.5rem; margin-bottom: 1.5rem; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+        .stats-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; }
+        .stat { text-align: center; padding: 1rem; }
+        .stat-value { font-size: 2rem; font-weight: bold; color: #111; }
+        .stat-label { font-size: 0.875rem; color: #6b7280; }
+        table { width: 100%; border-collapse: collapse; }
+        th, td { padding: 0.75rem 1rem; text-align: left; border-bottom: 1px solid #e5e7eb; }
+        th { background: #f9fafb; font-weight: 600; color: #374151; }
+        tr:hover { background: #f9fafb; }
+        .bar-container { width: 100%; background: #e5e7eb; border-radius: 4px; height: 8px; }
+        .bar { height: 100%; border-radius: 4px; }
+        .bar-productive { background: #4ade80; }
+        .bar-reading { background: #facc15; }
+        .bar-executing { background: #60a5fa; }
+        .bar-error { background: #f87171; }
+        .bar-gap { background: #9ca3af; }
+        .bar-thinking { background: #c4b5fd; }
+        .recommendation { padding: 0.75rem 1rem; margin: 0.5rem 0; background: #f0f9ff; border-left: 4px solid #3b82f6; border-radius: 0 4px 4px 0; }
+        .flamegraph-container { margin-top: 1rem; overflow-x: auto; }
+        .flamegraph-container svg { max-width: 100%; height: auto; }
+        .footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #e5e7eb; color: #9ca3af; font-size: 0.875rem; text-align: center; }
+    </style>
+</head>
+<body>
+    <h1>rcatalan98/ai-session-tracker</h1>
+    <p class="subtitle">AI Session Report</p>
+    <p class="date-range">January 13, 2026 — January 13, 2026</p>
+
+    <h2>Summary</h2>
+    <div class="card">
+        <div class="stats-grid">
+            <div class="stat">
+                <div class="stat-value">3</div>
+                <div class="stat-label">Sessions</div>
+            </div>
+            <div class="stat">
+                <div class="stat-value">8m</div>
+                <div class="stat-label">Total Time</div>
+            </div>
+            <div class="stat">
+                <div class="stat-value">99%</div>
+                <div class="stat-label">Efficiency</div>
+            </div>
+        </div>
+    </div>
+
+    <h2>Time Breakdown</h2>
+    <div class="card">
+        <table>
+            <thead>
+                <tr><th>Activity</th><th>Time</th><th>%</th><th>Distribution</th></tr>
+            </thead>
+            <tbody>
+                <tr>
+                <td>Thinking</td>
+                <td>8m</td>
+                <td>95%</td>
+                <td><div class="bar-container"><div class="bar bar-thinking" style="width: 95%"></div></div></td>
+            </tr><tr>
+                <td>Executing</td>
+                <td>0m</td>
+                <td>3%</td>
+                <td><div class="bar-container"><div class="bar bar-executing" style="width: 3%"></div></div></td>
+            </tr><tr>
+                <td>Error</td>
+                <td>0m</td>
+                <td>0%</td>
+                <td><div class="bar-container"><div class="bar bar-error" style="width: 0%"></div></div></td>
+            </tr><tr>
+                <td>Productive</td>
+                <td>0m</td>
+                <td>0%</td>
+                <td><div class="bar-container"><div class="bar bar-productive" style="width: 0%"></div></div></td>
+            </tr><tr>
+                <td>Reading/Search</td>
+                <td>0m</td>
+                <td>0%</td>
+                <td><div class="bar-container"><div class="bar bar-reading" style="width: 0%"></div></div></td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <h2>Bottlenecks</h2>
+    <div class="card">
+        <table>
+            <thead>
+                <tr><th>Type</th><th>Count</th><th>Time Lost</th></tr>
+            </thead>
+            <tbody>
+                <tr><td>Error Loop</td><td>3</td><td>3m</td></tr>
+            </tbody>
+        </table>
+    </div>
+
+    <h2>PR Breakdown</h2>
+    <div class="card">
+        <table>
+            <thead>
+                <tr><th>PR</th><th>Title</th><th>Time</th><th>Sessions</th></tr>
+            </thead>
+            <tbody>
+                <tr><td>#16</td><td>feat: GitHub integration for issue-level time t...</td><td>8m</td><td>3</td></tr>
+            </tbody>
+        </table>
+    </div>
+
+    <h2>Recommendations</h2>
+    <div class="card">
+        <div class="recommendation"><strong>3 error loops</strong> detected. Consider providing more context or examples when asking for help.</div>
+    </div>
+
+    <h2>Session Flamegraph</h2>
+    <div class="card">
+        <div class="flamegraph-container">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 180" width="1200" height="180">
+<style>
+  .pr-label { font: bold 12px monospace; fill: #374151; }
+  .stats-label { font: 10px monospace; fill: #6b7280; }
+  .legend-label { font: 12px sans-serif; fill: #374151; }
+  .title { font: bold 16px sans-serif; fill: #111827; }
+  rect.span { stroke: #fff; stroke-width: 1; }
+  rect.span:hover { stroke: #000; stroke-width: 2; opacity: 0.8; }
+</style>
+<rect width="100%" height="100%" fill="#f9fafb"/>
+<text x="40" y="25" class="title">AI Session Flamegraph (by PR)</text><rect x="40" y="45" width="14" height="14" fill="#4ade80" rx="2"/>
+<text x="58" y="56" class="legend-label">Productive</text><rect x="160" y="45" width="14" height="14" fill="#facc15" rx="2"/>
+<text x="178" y="56" class="legend-label">Reading/Search</text><rect x="300" y="45" width="14" height="14" fill="#60a5fa" rx="2"/>
+<text x="318" y="56" class="legend-label">Executing</text><rect x="420" y="45" width="14" height="14" fill="#f87171" rx="2"/>
+<text x="438" y="56" class="legend-label">Error</text><rect x="510" y="45" width="14" height="14" fill="#9ca3af" rx="2"/>
+<text x="528" y="56" class="legend-label">Gap/Pause</text><rect x="610" y="45" width="14" height="14" fill="#c4b5fd" rx="2"/>
+<text x="628" y="56" class="legend-label">Thinking</text><text x="40" y="120" class="pr-label">PR #16 feat: GitHub inte...</text>
+<text x="40" y="134" class="stats-label">3 sessions, 8m</text><rect x="220" y="104" width="940" height="32" fill="#e5e7eb" rx="3"/><rect class="span" x="220" y="104" width="35" height="32" fill="#60a5fa" rx="2">
+<title>Executing: 0m (3%)</title>
+</rect><rect class="span" x="255" y="104" width="7" height="32" fill="#f87171" rx="2">
+<title>Error: 0m (0%)</title>
+</rect><rect class="span" x="262" y="104" width="987" height="32" fill="#c4b5fd" rx="2">
+<title>Thinking: 8m (105%)</title>
+</rect></svg>
+        </div>
+    </div>
+
+    <div class="footer">
+        Generated by <strong>aist</strong> (AI Session Tracker) • 2026-01-13 21:00
+    </div>
+</body>
+</html>

--- a/src/bottlenecks.rs
+++ b/src/bottlenecks.rs
@@ -1,4 +1,4 @@
-use crate::parser::{MessageType, Session};
+use crate::parser::{Message, MessageType, Session};
 use chrono::{DateTime, Utc};
 use colored::Colorize;
 use std::collections::HashMap;
@@ -24,6 +24,7 @@ pub struct ErrorLoop {
     pub end_time: Option<DateTime<Utc>>,
     pub duration_minutes: f64,
     pub error_samples: Vec<String>,
+    pub preceding_prompt: Option<String>,
 }
 
 /// >10 Read/Grep calls with 0 Edit in 10+ minutes
@@ -37,6 +38,7 @@ pub struct ExplorationSpiral {
     pub duration_minutes: f64,
     pub start_time: Option<DateTime<Utc>>,
     pub files_searched: Vec<String>,
+    pub preceding_prompt: Option<String>,
 }
 
 /// Same file edited 5+ times in a session
@@ -47,6 +49,7 @@ pub struct EditThrashing {
     pub file_path: String,
     pub edit_count: usize,
     pub duration_minutes: f64,
+    pub preceding_prompt: Option<String>,
 }
 
 /// >5 minutes between consecutive messages
@@ -58,6 +61,7 @@ pub struct LongGap {
     pub gap_minutes: f64,
     pub before_timestamp: Option<DateTime<Utc>>,
     pub after_timestamp: Option<DateTime<Utc>>,
+    pub preceding_prompt: Option<String>,
 }
 
 #[allow(dead_code)] // Methods will be used in report generation
@@ -88,6 +92,38 @@ impl Bottleneck {
             Bottleneck::LongGap(g) => &g.project,
         }
     }
+
+    pub fn preceding_prompt(&self) -> Option<&str> {
+        match self {
+            Bottleneck::ErrorLoop(e) => e.preceding_prompt.as_deref(),
+            Bottleneck::ExplorationSpiral(e) => e.preceding_prompt.as_deref(),
+            Bottleneck::EditThrashing(e) => e.preceding_prompt.as_deref(),
+            Bottleneck::LongGap(g) => g.preceding_prompt.as_deref(),
+        }
+    }
+}
+
+/// Truncate text to max chars, adding "..." if truncated
+fn truncate_prompt(text: &str, max_chars: usize) -> String {
+    if text.len() <= max_chars {
+        text.to_string()
+    } else {
+        format!("{}...", &text[..max_chars])
+    }
+}
+
+/// Find the last user message with text content before the given message index
+fn find_preceding_prompt(messages: &[Message], before_index: usize) -> Option<String> {
+    for i in (0..before_index).rev() {
+        if messages[i].msg_type == MessageType::User {
+            if let Some(text) = &messages[i].text_content {
+                if !text.is_empty() {
+                    return Some(truncate_prompt(text, 200));
+                }
+            }
+        }
+    }
+    None
 }
 
 /// Detect all bottlenecks in a set of sessions
@@ -115,13 +151,13 @@ pub fn detect_all(sessions: &[Session]) -> Vec<Bottleneck> {
 fn detect_error_loops(session: &Session) -> Vec<Bottleneck> {
     let mut bottlenecks = Vec::new();
 
-    // Build a list of (tool_name, is_error, timestamp) from tool results
-    let mut tool_results: Vec<(String, bool, Option<DateTime<Utc>>)> = Vec::new();
+    // Build a list of (tool_name, is_error, timestamp, msg_index) from tool results
+    let mut tool_results: Vec<(String, bool, Option<DateTime<Utc>>, usize)> = Vec::new();
 
     // Track tool_use_id -> tool_name mapping
     let mut tool_id_to_name: HashMap<String, String> = HashMap::new();
 
-    for msg in &session.messages {
+    for (msg_idx, msg) in session.messages.iter().enumerate() {
         // Record tool calls
         if msg.msg_type == MessageType::Assistant {
             for tc in &msg.tool_calls {
@@ -139,7 +175,7 @@ fn detect_error_loops(session: &Session) -> Vec<Bottleneck> {
                     .get(&tr.tool_use_id)
                     .cloned()
                     .unwrap_or_else(|| "unknown".to_string());
-                tool_results.push((tool_name, is_error, msg.timestamp));
+                tool_results.push((tool_name, is_error, msg.timestamp, msg_idx));
             }
         }
     }
@@ -151,6 +187,7 @@ fn detect_error_loops(session: &Session) -> Vec<Bottleneck> {
             // Found an error
             let tool_name = &tool_results[i].0;
             let start_time = tool_results[i].2;
+            let start_msg_idx = tool_results[i].3;
             let mut count = 1;
             let error_samples: Vec<String> = Vec::new();
 
@@ -169,6 +206,8 @@ fn detect_error_loops(session: &Session) -> Vec<Bottleneck> {
                     _ => 0.0,
                 };
 
+                let preceding_prompt = find_preceding_prompt(&session.messages, start_msg_idx);
+
                 bottlenecks.push(Bottleneck::ErrorLoop(ErrorLoop {
                     session_id: session.session_id.clone(),
                     project: extract_project_name(&session.project),
@@ -178,6 +217,7 @@ fn detect_error_loops(session: &Session) -> Vec<Bottleneck> {
                     end_time,
                     duration_minutes: duration.max(1.0), // At least 1 minute
                     error_samples,
+                    preceding_prompt,
                 }));
             }
 
@@ -199,15 +239,17 @@ fn detect_exploration_spirals(session: &Session) -> Vec<Bottleneck> {
     let mut grep_count = 0;
     let mut files_searched: Vec<String> = Vec::new();
     let mut window_start: Option<DateTime<Utc>> = None;
+    let mut window_start_idx: usize = 0;
     let mut last_edit_time: Option<DateTime<Utc>> = None;
 
-    for msg in &session.messages {
+    for (msg_idx, msg) in session.messages.iter().enumerate() {
         if msg.msg_type == MessageType::Assistant {
             for tc in &msg.tool_calls {
                 match tc.name.as_str() {
                     "Read" => {
                         if window_start.is_none() {
                             window_start = msg.timestamp;
+                            window_start_idx = msg_idx;
                         }
                         read_count += 1;
                         if let Some(path) = tc.input.get("file_path").and_then(|v| v.as_str()) {
@@ -219,6 +261,7 @@ fn detect_exploration_spirals(session: &Session) -> Vec<Bottleneck> {
                     "Grep" | "Glob" => {
                         if window_start.is_none() {
                             window_start = msg.timestamp;
+                            window_start_idx = msg_idx;
                         }
                         grep_count += 1;
                     }
@@ -230,6 +273,8 @@ fn detect_exploration_spirals(session: &Session) -> Vec<Bottleneck> {
                                 let duration = (end - start).num_seconds() as f64 / 60.0;
 
                                 if duration >= 10.0 {
+                                    let preceding_prompt =
+                                        find_preceding_prompt(&session.messages, window_start_idx);
                                     bottlenecks.push(Bottleneck::ExplorationSpiral(
                                         ExplorationSpiral {
                                             session_id: session.session_id.clone(),
@@ -239,6 +284,7 @@ fn detect_exploration_spirals(session: &Session) -> Vec<Bottleneck> {
                                             duration_minutes: duration,
                                             start_time: Some(start),
                                             files_searched: files_searched.clone(),
+                                            preceding_prompt,
                                         },
                                     ));
                                 }
@@ -263,6 +309,7 @@ fn detect_exploration_spirals(session: &Session) -> Vec<Bottleneck> {
         if let (Some(start), Some(end)) = (window_start, session.end_time) {
             let duration = (end - start).num_seconds() as f64 / 60.0;
             if duration >= 10.0 {
+                let preceding_prompt = find_preceding_prompt(&session.messages, window_start_idx);
                 bottlenecks.push(Bottleneck::ExplorationSpiral(ExplorationSpiral {
                     session_id: session.session_id.clone(),
                     project: extract_project_name(&session.project),
@@ -271,6 +318,7 @@ fn detect_exploration_spirals(session: &Session) -> Vec<Bottleneck> {
                     duration_minutes: duration,
                     start_time: Some(start),
                     files_searched,
+                    preceding_prompt,
                 }));
             }
         }
@@ -283,14 +331,14 @@ fn detect_exploration_spirals(session: &Session) -> Vec<Bottleneck> {
 fn detect_edit_thrashing(session: &Session) -> Vec<Bottleneck> {
     let mut bottlenecks = Vec::new();
 
-    // Count edits per file: (count, first_edit, last_edit)
+    // Count edits per file: (count, first_edit, last_edit, first_msg_idx)
     #[allow(clippy::type_complexity)]
     let mut edit_counts: HashMap<
         String,
-        (usize, Option<DateTime<Utc>>, Option<DateTime<Utc>>),
+        (usize, Option<DateTime<Utc>>, Option<DateTime<Utc>>, usize),
     > = HashMap::new();
 
-    for msg in &session.messages {
+    for (msg_idx, msg) in session.messages.iter().enumerate() {
         if msg.msg_type == MessageType::Assistant {
             for tc in &msg.tool_calls {
                 if tc.name == "Edit" || tc.name == "Write" {
@@ -299,6 +347,7 @@ fn detect_edit_thrashing(session: &Session) -> Vec<Bottleneck> {
                             0,
                             msg.timestamp,
                             msg.timestamp,
+                            msg_idx,
                         ));
                         entry.0 += 1;
                         entry.2 = msg.timestamp; // Update end time
@@ -309,12 +358,14 @@ fn detect_edit_thrashing(session: &Session) -> Vec<Bottleneck> {
     }
 
     // Find files with 5+ edits
-    for (file_path, (count, start, end)) in edit_counts {
+    for (file_path, (count, start, end, first_msg_idx)) in edit_counts {
         if count >= 5 {
             let duration = match (start, end) {
                 (Some(s), Some(e)) => (e - s).num_seconds() as f64 / 60.0,
                 _ => 0.0,
             };
+
+            let preceding_prompt = find_preceding_prompt(&session.messages, first_msg_idx);
 
             bottlenecks.push(Bottleneck::EditThrashing(EditThrashing {
                 session_id: session.session_id.clone(),
@@ -322,6 +373,7 @@ fn detect_edit_thrashing(session: &Session) -> Vec<Bottleneck> {
                 file_path: shorten_path(&file_path),
                 edit_count: count,
                 duration_minutes: duration.max(1.0),
+                preceding_prompt,
             }));
         }
     }
@@ -334,23 +386,30 @@ fn detect_long_gaps(session: &Session) -> Vec<Bottleneck> {
     let mut bottlenecks = Vec::new();
 
     let mut prev_timestamp: Option<DateTime<Utc>> = None;
+    let mut prev_msg_idx: usize = 0;
 
-    for msg in &session.messages {
+    for (msg_idx, msg) in session.messages.iter().enumerate() {
         if let Some(ts) = msg.timestamp {
             if let Some(prev) = prev_timestamp {
                 let gap_minutes = (ts - prev).num_seconds() as f64 / 60.0;
 
                 if gap_minutes >= 5.0 {
+                    // Find the user prompt before the gap
+                    let preceding_prompt =
+                        find_preceding_prompt(&session.messages, prev_msg_idx + 1);
+
                     bottlenecks.push(Bottleneck::LongGap(LongGap {
                         session_id: session.session_id.clone(),
                         project: extract_project_name(&session.project),
                         gap_minutes,
                         before_timestamp: Some(prev),
                         after_timestamp: Some(ts),
+                        preceding_prompt,
                     }));
                 }
             }
             prev_timestamp = Some(ts);
+            prev_msg_idx = msg_idx;
         }
     }
 
@@ -552,7 +611,9 @@ mod tests {
             end_time: None,
             duration_minutes: 5.0,
             error_samples: vec![],
+            preceding_prompt: Some("help me fix this bug".to_string()),
         });
         assert_eq!(error_loop.wasted_minutes(), 5.0);
+        assert_eq!(error_loop.preceding_prompt(), Some("help me fix this bug"));
     }
 }

--- a/src/bottlenecks.rs
+++ b/src/bottlenecks.rs
@@ -445,7 +445,7 @@ fn shorten_path(path: &str) -> String {
 }
 
 /// Print bottlenecks to terminal
-pub fn print_bottlenecks(bottlenecks: &[Bottleneck], limit: usize) {
+pub fn print_bottlenecks(bottlenecks: &[Bottleneck], limit: usize, show_prompts: bool) {
     if bottlenecks.is_empty() {
         println!("{}", "No bottlenecks detected.".green());
         return;
@@ -462,7 +462,7 @@ pub fn print_bottlenecks(bottlenecks: &[Bottleneck], limit: usize) {
     );
 
     for (i, bottleneck) in bottlenecks.iter().take(limit).enumerate() {
-        print_single_bottleneck(i + 1, bottleneck);
+        print_single_bottleneck(i + 1, bottleneck, show_prompts);
         println!();
     }
 
@@ -474,7 +474,7 @@ pub fn print_bottlenecks(bottlenecks: &[Bottleneck], limit: usize) {
     }
 }
 
-fn print_single_bottleneck(num: usize, bottleneck: &Bottleneck) {
+fn print_single_bottleneck(num: usize, bottleneck: &Bottleneck, show_prompt: bool) {
     match bottleneck {
         Bottleneck::ErrorLoop(e) => {
             println!(
@@ -569,6 +569,16 @@ fn print_single_bottleneck(num: usize, bottleneck: &Bottleneck) {
                 "   {}",
                 "Suggestion: Review what caused the pause - unclear requirements?".cyan()
             );
+        }
+    }
+
+    // Show preceding prompt if requested
+    if show_prompt {
+        if let Some(prompt) = bottleneck.preceding_prompt() {
+            println!("   {}", "Prompt:".dimmed());
+            println!("   {}", format!("\"{}\"", prompt).italic().dimmed());
+        } else {
+            println!("   {}", "Prompt: (no prompt found)".dimmed());
         }
     }
 }

--- a/src/cost.rs
+++ b/src/cost.rs
@@ -1,0 +1,167 @@
+use crate::metrics::filter_by_period;
+use crate::parser::Session;
+use colored::Colorize;
+
+/// Claude Opus 4.5 pricing per million tokens (as of 2026)
+const INPUT_PRICE_PER_MILLION: f64 = 15.0;
+const OUTPUT_PRICE_PER_MILLION: f64 = 75.0;
+
+/// Calculate cost from token counts
+pub fn calculate_cost(input_tokens: u64, output_tokens: u64) -> f64 {
+    let input_cost = (input_tokens as f64 / 1_000_000.0) * INPUT_PRICE_PER_MILLION;
+    let output_cost = (output_tokens as f64 / 1_000_000.0) * OUTPUT_PRICE_PER_MILLION;
+    input_cost + output_cost
+}
+
+/// Format cost as USD
+fn format_cost(cost: f64) -> String {
+    if cost < 0.01 {
+        format!("${:.4}", cost)
+    } else {
+        format!("${:.2}", cost)
+    }
+}
+
+/// Format token count with commas
+fn format_tokens(count: u64) -> String {
+    let s = count.to_string();
+    let mut result = String::new();
+    for (i, c) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            result.push(',');
+        }
+        result.push(c);
+    }
+    result.chars().rev().collect()
+}
+
+/// Print cost summary for sessions
+pub fn print_cost_summary(sessions: &[Session], period: &str, detailed: bool) {
+    let filtered = filter_by_period(sessions, period);
+
+    if filtered.is_empty() {
+        println!("{}", "No sessions found.".yellow());
+        return;
+    }
+
+    // Calculate totals
+    let total_input: u64 = filtered.iter().map(|s| s.token_input).sum();
+    let total_output: u64 = filtered.iter().map(|s| s.token_output).sum();
+    let total_cost = calculate_cost(total_input, total_output);
+
+    // Header
+    println!("{}", "TOKEN USAGE & COST".bold());
+    println!("{}", "═".repeat(50));
+    println!(
+        "Period: {} | Sessions: {}",
+        period.bold(),
+        filtered.len().to_string().bold()
+    );
+    println!();
+
+    // Summary
+    println!("{}", "SUMMARY".bold());
+    println!("{}", "─".repeat(30));
+    println!(
+        "Input tokens:   {:>15} ({})",
+        format_tokens(total_input),
+        format_cost((total_input as f64 / 1_000_000.0) * INPUT_PRICE_PER_MILLION).dimmed()
+    );
+    println!(
+        "Output tokens:  {:>15} ({})",
+        format_tokens(total_output),
+        format_cost((total_output as f64 / 1_000_000.0) * OUTPUT_PRICE_PER_MILLION).dimmed()
+    );
+    println!("{}", "─".repeat(30));
+    println!(
+        "Total cost:     {:>15}",
+        format_cost(total_cost).green().bold()
+    );
+    println!();
+
+    // Pricing note
+    println!(
+        "{}",
+        format!(
+            "Pricing: ${}/M input, ${}/M output (Claude Opus 4.5)",
+            INPUT_PRICE_PER_MILLION as u32, OUTPUT_PRICE_PER_MILLION as u32
+        )
+        .dimmed()
+    );
+    println!();
+
+    // Detailed breakdown if requested
+    if detailed {
+        println!("{}", "PER-SESSION BREAKDOWN".bold());
+        println!("{}", "─".repeat(70));
+        println!(
+            "{:<12} {:>15} {:>15} {:>12}",
+            "SESSION".dimmed(),
+            "INPUT".dimmed(),
+            "OUTPUT".dimmed(),
+            "COST".dimmed()
+        );
+
+        // Sort sessions by cost (descending)
+        let mut sorted: Vec<_> = filtered.iter().collect();
+        sorted.sort_by(|a, b| {
+            let cost_a = calculate_cost(a.token_input, a.token_output);
+            let cost_b = calculate_cost(b.token_input, b.token_output);
+            cost_b
+                .partial_cmp(&cost_a)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        for session in sorted.iter().take(20) {
+            let session_cost = calculate_cost(session.token_input, session.token_output);
+            let session_short: String = session.session_id.chars().take(10).collect();
+
+            println!(
+                "{:<12} {:>15} {:>15} {:>12}",
+                session_short,
+                format_tokens(session.token_input),
+                format_tokens(session.token_output),
+                format_cost(session_cost)
+            );
+        }
+
+        if sorted.len() > 20 {
+            println!(
+                "{}",
+                format!("... and {} more sessions", sorted.len() - 20).dimmed()
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_calculate_cost() {
+        // 1M input tokens = $15
+        assert_eq!(calculate_cost(1_000_000, 0), 15.0);
+        // 1M output tokens = $75
+        assert_eq!(calculate_cost(0, 1_000_000), 75.0);
+        // Combined
+        assert_eq!(calculate_cost(1_000_000, 1_000_000), 90.0);
+    }
+
+    #[test]
+    fn test_format_tokens() {
+        assert_eq!(format_tokens(0), "0");
+        assert_eq!(format_tokens(999), "999");
+        assert_eq!(format_tokens(1000), "1,000");
+        assert_eq!(format_tokens(1234567), "1,234,567");
+    }
+
+    #[test]
+    fn test_format_cost() {
+        assert_eq!(format_cost(0.0001), "$0.0001");
+        assert_eq!(format_cost(0.009), "$0.0090");
+        assert_eq!(format_cost(0.05), "$0.05");
+        assert_eq!(format_cost(1.50), "$1.50");
+        assert_eq!(format_cost(15.0), "$15.00");
+    }
+}

--- a/src/export.rs
+++ b/src/export.rs
@@ -525,6 +525,8 @@ mod tests {
             start_time: Some(start),
             end_time: Some(end),
             messages: vec![],
+            token_input: 0,
+            token_output: 0,
         }
     }
 

--- a/src/issues.rs
+++ b/src/issues.rs
@@ -385,6 +385,8 @@ mod tests {
             start_time: Some(start),
             end_time: Some(end),
             messages: vec![],
+            token_input: 0,
+            token_output: 0,
         }
     }
 

--- a/src/issues.rs
+++ b/src/issues.rs
@@ -1,3 +1,4 @@
+use crate::cost::calculate_cost;
 use crate::flamegraph::{extract_spans, ActivityType};
 use crate::github::{load_current_repo_cache, PrMapping, RepoCache};
 use crate::parser::Session;
@@ -14,6 +15,7 @@ pub struct IssueMetrics {
     pub branch: String,
     pub total_minutes: f64,
     pub session_count: usize,
+    pub cost: f64,
 }
 
 /// Calculate time spent per issue by matching sessions to PR branches
@@ -25,8 +27,8 @@ pub fn calculate_issue_metrics(sessions: &[Session], cache: &RepoCache) -> Vec<I
         .map(|pr| (pr.branch.as_str(), pr))
         .collect();
 
-    // Build issue -> (title, branch, minutes, session_count)
-    let mut issue_metrics: HashMap<u32, (String, String, f64, usize)> = HashMap::new();
+    // Build issue -> (title, branch, minutes, session_count, input_tokens, output_tokens)
+    let mut issue_metrics: HashMap<u32, (String, String, f64, usize, u64, u64)> = HashMap::new();
 
     for session in sessions {
         let branch = match &session.git_branch {
@@ -51,13 +53,15 @@ pub fn calculate_issue_metrics(sessions: &[Session], cache: &RepoCache) -> Vec<I
             _ => 0.0,
         };
 
-        // Add time to each linked issue
+        // Add time and tokens to each linked issue
         for &issue_num in &pr.closed_issues {
             let entry = issue_metrics
                 .entry(issue_num)
-                .or_insert_with(|| (pr.title.clone(), pr.branch.clone(), 0.0, 0));
+                .or_insert_with(|| (pr.title.clone(), pr.branch.clone(), 0.0, 0, 0, 0));
             entry.2 += duration_minutes;
             entry.3 += 1;
+            entry.4 += session.token_input;
+            entry.5 += session.token_output;
         }
     }
 
@@ -65,12 +69,15 @@ pub fn calculate_issue_metrics(sessions: &[Session], cache: &RepoCache) -> Vec<I
     let mut metrics: Vec<IssueMetrics> = issue_metrics
         .into_iter()
         .map(
-            |(issue_number, (title, branch, total_minutes, session_count))| IssueMetrics {
-                issue_number,
-                title,
-                branch,
-                total_minutes,
-                session_count,
+            |(issue_number, (title, branch, total_minutes, session_count, input, output))| {
+                IssueMetrics {
+                    issue_number,
+                    title,
+                    branch,
+                    total_minutes,
+                    session_count,
+                    cost: calculate_cost(input, output),
+                }
             },
         )
         .collect();
@@ -92,6 +99,15 @@ fn format_duration(minutes: f64) -> String {
         format!("{}h {}m", hours as u32, mins as u32)
     } else {
         format!("{}m", minutes.round() as u32)
+    }
+}
+
+/// Format cost as USD
+fn format_cost(cost: f64) -> String {
+    if cost < 0.01 {
+        format!("${:.4}", cost)
+    } else {
+        format!("${:.2}", cost)
     }
 }
 
@@ -123,51 +139,56 @@ pub fn list_issues(sessions: &[Session]) {
     // Calculate totals
     let total_time: f64 = metrics.iter().map(|m| m.total_minutes).sum();
     let total_sessions: usize = metrics.iter().map(|m| m.session_count).sum();
+    let total_cost: f64 = metrics.iter().map(|m| m.cost).sum();
 
     // Header
     println!("{}", "ISSUES BY TIME".bold());
-    println!("{}", "═".repeat(70));
+    println!("{}", "═".repeat(82));
     println!(
-        "{} issues | {} sessions | {} total\n",
+        "{} issues | {} sessions | {} total | {} cost\n",
         metrics.len().to_string().bold(),
         total_sessions.to_string().bold(),
-        format_duration(total_time).bold()
+        format_duration(total_time).bold(),
+        format_cost(total_cost).green().bold()
     );
 
     // Column headers
     println!(
-        "{:<8} {:<40} {:>10} {:>10}",
+        "{:<8} {:<38} {:>10} {:>10} {:>10}",
         "ISSUE".dimmed(),
         "TITLE".dimmed(),
         "TIME".dimmed(),
-        "SESSIONS".dimmed()
+        "SESSIONS".dimmed(),
+        "COST".dimmed()
     );
-    println!("{}", "─".repeat(70).dimmed());
+    println!("{}", "─".repeat(82).dimmed());
 
     // List issues
     for m in &metrics {
-        let title_display = if m.title.len() > 38 {
-            format!("{}...", &m.title[..35])
+        let title_display = if m.title.len() > 36 {
+            format!("{}...", &m.title[..33])
         } else {
             m.title.clone()
         };
 
         println!(
-            "#{:<7} {:<40} {:>10} {:>10}",
+            "#{:<7} {:<38} {:>10} {:>10} {:>10}",
             m.issue_number,
             title_display,
             format_duration(m.total_minutes),
-            m.session_count
+            m.session_count,
+            format_cost(m.cost)
         );
     }
 
-    println!("{}", "─".repeat(70).dimmed());
+    println!("{}", "─".repeat(82).dimmed());
     println!(
-        "{:<8} {:<40} {:>10} {:>10}",
+        "{:<8} {:<38} {:>10} {:>10} {:>10}",
         "TOTAL".bold(),
         "",
         format_duration(total_time).bold(),
-        total_sessions.to_string().bold()
+        total_sessions.to_string().bold(),
+        format_cost(total_cost).green().bold()
     );
 }
 
@@ -233,6 +254,9 @@ pub fn show_issue_detail(issue_number: u32, sessions: &[Session]) {
     // Calculate totals
     let total_time: f64 = issue_sessions.iter().map(|s| s.duration_minutes).sum();
     let session_count = issue_sessions.len();
+    let total_input: u64 = issue_sessions.iter().map(|s| s.session.token_input).sum();
+    let total_output: u64 = issue_sessions.iter().map(|s| s.session.token_output).sum();
+    let total_cost = calculate_cost(total_input, total_output);
 
     // Determine status
     let status = if pr.merged_at.is_some() {
@@ -256,6 +280,11 @@ pub fn show_issue_detail(issue_number: u32, sessions: &[Session]) {
         format_duration(total_time).bold()
     );
     println!("{}: {}", "Sessions".dimmed(), session_count);
+    println!(
+        "{}: {}",
+        "Cost".dimmed(),
+        format_cost(total_cost).green().bold()
+    );
     println!();
 
     if issue_sessions.is_empty() {
@@ -431,10 +460,12 @@ mod tests {
         assert_eq!(metrics[0].issue_number, 1);
         assert_eq!(metrics[0].total_minutes, 75.0);
         assert_eq!(metrics[0].session_count, 2);
+        assert_eq!(metrics[0].cost, 0.0); // No tokens in test sessions
 
         assert_eq!(metrics[1].issue_number, 2);
         assert_eq!(metrics[1].total_minutes, 20.0);
         assert_eq!(metrics[1].session_count, 1);
+        assert_eq!(metrics[1].cost, 0.0);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,10 @@ enum Commands {
         /// Number of bottlenecks to show
         #[arg(short, long, default_value = "10")]
         limit: usize,
+
+        /// Show the user prompt that preceded each bottleneck
+        #[arg(long)]
+        show_prompts: bool,
     },
 
     /// Generate a summary report
@@ -166,8 +170,12 @@ fn main() {
         Commands::Analyze { project, verbose } => {
             analyze_command(project, verbose);
         }
-        Commands::Bottlenecks { project, limit } => {
-            bottlenecks_command(project, limit);
+        Commands::Bottlenecks {
+            project,
+            limit,
+            show_prompts,
+        } => {
+            bottlenecks_command(project, limit, show_prompts);
         }
         Commands::Report { period, format } => {
             report_command(&period, &format);
@@ -321,7 +329,7 @@ fn analyze_command(project: Option<PathBuf>, verbose: bool) {
     );
 }
 
-fn bottlenecks_command(project: Option<PathBuf>, limit: usize) {
+fn bottlenecks_command(project: Option<PathBuf>, limit: usize, show_prompts: bool) {
     let sessions = parser::load_sessions(project.as_deref());
 
     if sessions.is_empty() {
@@ -330,7 +338,7 @@ fn bottlenecks_command(project: Option<PathBuf>, limit: usize) {
     }
 
     let detected = bottlenecks::detect_all(&sessions);
-    bottlenecks::print_bottlenecks(&detected, limit);
+    bottlenecks::print_bottlenecks(&detected, limit, show_prompts);
 }
 
 fn report_command(period: &str, format: &str) {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -251,6 +251,8 @@ mod tests {
                     text_content: None,
                 },
             ],
+            token_input: 1000,
+            token_output: 500,
         }
     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -214,6 +214,7 @@ mod tests {
                     timestamp: Some(start),
                     tool_calls: vec![],
                     tool_results: vec![],
+                    text_content: Some("help me with this".to_string()),
                 },
                 Message {
                     msg_type: MessageType::Assistant,
@@ -229,6 +230,7 @@ mod tests {
                         },
                     ],
                     tool_results: vec![],
+                    text_content: None,
                 },
                 Message {
                     msg_type: MessageType::User,
@@ -246,6 +248,7 @@ mod tests {
                             is_error: true,
                         },
                     ],
+                    text_content: None,
                 },
             ],
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -16,6 +16,10 @@ pub struct Session {
     pub start_time: Option<DateTime<Utc>>,
     pub end_time: Option<DateTime<Utc>>,
     pub messages: Vec<Message>,
+    /// Total input tokens consumed in this session
+    pub token_input: u64,
+    /// Total output tokens consumed in this session
+    pub token_output: u64,
 }
 
 /// A message in a session
@@ -71,6 +75,17 @@ struct RawMessage {
 #[derive(Debug, Deserialize)]
 struct RawMessageContent {
     content: Option<serde_json::Value>,
+    usage: Option<RawUsage>,
+}
+
+/// Token usage data from Claude API responses
+#[derive(Debug, Deserialize)]
+struct RawUsage {
+    input_tokens: Option<u64>,
+    output_tokens: Option<u64>,
+    cache_creation_input_tokens: Option<u64>,
+    #[allow(dead_code)]
+    cache_read_input_tokens: Option<u64>, // Usually free, not counted
 }
 
 /// Get the Claude projects directory
@@ -132,6 +147,8 @@ fn parse_session_file(path: &Path) -> Option<Session> {
     let mut git_branch = None;
     let mut messages = vec![];
     let mut timestamps: Vec<DateTime<Utc>> = vec![];
+    let mut token_input: u64 = 0;
+    let mut token_output: u64 = 0;
 
     for line in reader.lines() {
         let line = match line {
@@ -187,6 +204,16 @@ fn parse_session_file(path: &Path) -> Option<Session> {
         // Parse tool calls, results, and text from message content
         let (tool_calls, tool_results, text_content) = parse_message_content(&raw.message);
 
+        // Extract token usage from assistant messages
+        if let Some(ref msg) = raw.message {
+            if let Some(ref usage) = msg.usage {
+                // input_tokens + cache_creation_input_tokens = billable input
+                token_input += usage.input_tokens.unwrap_or(0);
+                token_input += usage.cache_creation_input_tokens.unwrap_or(0);
+                token_output += usage.output_tokens.unwrap_or(0);
+            }
+        }
+
         messages.push(Message {
             msg_type,
             timestamp,
@@ -230,6 +257,8 @@ fn parse_session_file(path: &Path) -> Option<Session> {
         start_time,
         end_time,
         messages,
+        token_input,
+        token_output,
     })
 }
 

--- a/src/prs.rs
+++ b/src/prs.rs
@@ -413,6 +413,8 @@ mod tests {
             start_time: Some(start),
             end_time: Some(end),
             messages: vec![],
+            token_input: 0,
+            token_output: 0,
         }
     }
 

--- a/src/prs.rs
+++ b/src/prs.rs
@@ -1,3 +1,4 @@
+use crate::cost::calculate_cost;
 use crate::flamegraph::{extract_spans, ActivityType};
 use crate::github::{load_current_repo_cache, PrMapping, RepoCache};
 use crate::parser::Session;
@@ -16,6 +17,7 @@ pub struct PrMetrics {
     pub session_count: usize,
     pub merged_at: Option<String>,
     pub closed_issues: Vec<u32>,
+    pub cost: f64,
 }
 
 /// Calculate time spent per PR by matching sessions to PR branches
@@ -27,8 +29,8 @@ pub fn calculate_pr_metrics(sessions: &[Session], cache: &RepoCache) -> Vec<PrMe
         .map(|pr| (pr.branch.as_str(), pr))
         .collect();
 
-    // Build PR -> (minutes, session_count)
-    let mut pr_metrics: HashMap<u32, (f64, usize)> = HashMap::new();
+    // Build PR -> (minutes, session_count, input_tokens, output_tokens)
+    let mut pr_metrics: HashMap<u32, (f64, usize, u64, u64)> = HashMap::new();
 
     for session in sessions {
         let branch = match &session.git_branch {
@@ -48,31 +50,36 @@ pub fn calculate_pr_metrics(sessions: &[Session], cache: &RepoCache) -> Vec<PrMe
             _ => 0.0,
         };
 
-        // Add time to this PR
-        let entry = pr_metrics.entry(pr.pr_number).or_insert((0.0, 0));
+        // Add time and tokens to this PR
+        let entry = pr_metrics.entry(pr.pr_number).or_insert((0.0, 0, 0, 0));
         entry.0 += duration_minutes;
         entry.1 += 1;
+        entry.2 += session.token_input;
+        entry.3 += session.token_output;
     }
 
     // Convert to Vec with PR info
     let mut metrics: Vec<PrMetrics> = pr_metrics
         .into_iter()
-        .filter_map(|(pr_number, (total_minutes, session_count))| {
-            // Find the PR to get its metadata
-            cache
-                .prs
-                .iter()
-                .find(|p| p.pr_number == pr_number)
-                .map(|pr| PrMetrics {
-                    pr_number,
-                    title: pr.title.clone(),
-                    branch: pr.branch.clone(),
-                    total_minutes,
-                    session_count,
-                    merged_at: pr.merged_at.clone(),
-                    closed_issues: pr.closed_issues.clone(),
-                })
-        })
+        .filter_map(
+            |(pr_number, (total_minutes, session_count, input_tokens, output_tokens))| {
+                // Find the PR to get its metadata
+                cache
+                    .prs
+                    .iter()
+                    .find(|p| p.pr_number == pr_number)
+                    .map(|pr| PrMetrics {
+                        pr_number,
+                        title: pr.title.clone(),
+                        branch: pr.branch.clone(),
+                        total_minutes,
+                        session_count,
+                        merged_at: pr.merged_at.clone(),
+                        closed_issues: pr.closed_issues.clone(),
+                        cost: calculate_cost(input_tokens, output_tokens),
+                    })
+            },
+        )
         .collect();
 
     // Sort by total time descending
@@ -93,6 +100,15 @@ fn format_duration(minutes: f64) -> String {
         format!("{}h {}m", hours as u32, mins as u32)
     } else {
         format!("{}m", minutes.round() as u32)
+    }
+}
+
+/// Format cost as USD
+fn format_cost(cost: f64) -> String {
+    if cost < 0.01 {
+        format!("${:.4}", cost)
+    } else {
+        format!("${:.2}", cost)
     }
 }
 
@@ -124,32 +140,35 @@ pub fn list_prs(sessions: &[Session]) {
     // Calculate totals
     let total_time: f64 = metrics.iter().map(|m| m.total_minutes).sum();
     let total_sessions: usize = metrics.iter().map(|m| m.session_count).sum();
+    let total_cost: f64 = metrics.iter().map(|m| m.cost).sum();
 
     // Header
     println!("{}", "PRS BY TIME".bold());
-    println!("{}", "═".repeat(80));
+    println!("{}", "═".repeat(90));
     println!(
-        "{} PRs | {} sessions | {} total\n",
+        "{} PRs | {} sessions | {} total | {} cost\n",
         metrics.len().to_string().bold(),
         total_sessions.to_string().bold(),
-        format_duration(total_time).bold()
+        format_duration(total_time).bold(),
+        format_cost(total_cost).green().bold()
     );
 
     // Column headers
     println!(
-        "{:<8} {:<45} {:>10} {:>10} {:>6}",
+        "{:<8} {:<38} {:>10} {:>8} {:>10} {:>8}",
         "PR".dimmed(),
         "TITLE".dimmed(),
         "TIME".dimmed(),
         "SESSIONS".dimmed(),
+        "COST".dimmed(),
         "ISSUES".dimmed()
     );
-    println!("{}", "─".repeat(80).dimmed());
+    println!("{}", "─".repeat(90).dimmed());
 
     // List PRs
     for m in &metrics {
-        let title_display = if m.title.len() > 43 {
-            format!("{}...", &m.title[..40])
+        let title_display = if m.title.len() > 36 {
+            format!("{}...", &m.title[..33])
         } else {
             m.title.clone()
         };
@@ -164,29 +183,31 @@ pub fn list_prs(sessions: &[Session]) {
                 .join(",")
         };
 
-        let issues_display = if issues_str.len() > 6 {
+        let issues_display = if issues_str.len() > 8 {
             format!("{}+", m.closed_issues.len())
         } else {
             issues_str
         };
 
         println!(
-            "#{:<7} {:<45} {:>10} {:>10} {:>6}",
+            "#{:<7} {:<38} {:>10} {:>8} {:>10} {:>8}",
             m.pr_number,
             title_display,
             format_duration(m.total_minutes),
             m.session_count,
+            format_cost(m.cost),
             issues_display
         );
     }
 
-    println!("{}", "─".repeat(80).dimmed());
+    println!("{}", "─".repeat(90).dimmed());
     println!(
-        "{:<8} {:<45} {:>10} {:>10}",
+        "{:<8} {:<38} {:>10} {:>8} {:>10}",
         "TOTAL".bold(),
         "",
         format_duration(total_time).bold(),
-        total_sessions.to_string().bold()
+        total_sessions.to_string().bold(),
+        format_cost(total_cost).green().bold()
     );
 }
 
@@ -249,6 +270,9 @@ pub fn show_pr_detail(pr_number: u32, sessions: &[Session]) {
     // Calculate totals
     let total_time: f64 = pr_sessions.iter().map(|s| s.duration_minutes).sum();
     let session_count = pr_sessions.len();
+    let total_input: u64 = pr_sessions.iter().map(|s| s.session.token_input).sum();
+    let total_output: u64 = pr_sessions.iter().map(|s| s.session.token_output).sum();
+    let total_cost = calculate_cost(total_input, total_output);
 
     // Determine status
     let status = if pr.merged_at.is_some() {
@@ -284,6 +308,11 @@ pub fn show_pr_detail(pr_number: u32, sessions: &[Session]) {
         format_duration(total_time).bold()
     );
     println!("{}: {}", "Sessions".dimmed(), session_count);
+    println!(
+        "{}: {}",
+        "Cost".dimmed(),
+        format_cost(total_cost).green().bold()
+    );
     println!();
 
     if pr_sessions.is_empty() {
@@ -460,10 +489,12 @@ mod tests {
         assert_eq!(metrics[0].total_minutes, 75.0);
         assert_eq!(metrics[0].session_count, 2);
         assert_eq!(metrics[0].closed_issues, vec![1, 2]);
+        assert_eq!(metrics[0].cost, 0.0); // No tokens in test sessions
 
         assert_eq!(metrics[1].pr_number, 11);
         assert_eq!(metrics[1].total_minutes, 20.0);
         assert_eq!(metrics[1].session_count, 1);
+        assert_eq!(metrics[1].cost, 0.0);
     }
 
     #[test]

--- a/src/report.rs
+++ b/src/report.rs
@@ -473,12 +473,14 @@ mod tests {
                     timestamp: Some(start),
                     tool_calls: vec![],
                     tool_results: vec![],
+                    text_content: Some("help me".to_string()),
                 },
                 Message {
                     msg_type: MessageType::Assistant,
                     timestamp: Some(end),
                     tool_calls: vec![],
                     tool_results: vec![],
+                    text_content: None,
                 },
             ],
         }

--- a/src/report.rs
+++ b/src/report.rs
@@ -483,6 +483,8 @@ mod tests {
                     text_content: None,
                 },
             ],
+            token_input: 0,
+            token_output: 0,
         }
     }
 

--- a/src/timeline.rs
+++ b/src/timeline.rs
@@ -382,6 +382,8 @@ mod tests {
                 start_time: None,
                 end_time: None,
                 messages: vec![],
+                token_input: 0,
+                token_output: 0,
             },
             Session {
                 session_id: "xyz789ghi".to_string(),
@@ -391,6 +393,8 @@ mod tests {
                 start_time: None,
                 end_time: None,
                 messages: vec![],
+                token_input: 0,
+                token_output: 0,
             },
         ];
 


### PR DESCRIPTION
## Summary

- Add `--show-prompts` flag to `aist bottlenecks` to display the user prompt that preceded each bottleneck
- Add `aist cost` command to show token usage and estimated API costs
- Add cost columns to `aist prs` and `aist issues` output
- Parse token usage (input/output) from Claude transcripts

## User Stories Completed

- **US-001**: Extract prompts before bottlenecks - Parse and store the user message that preceded each detected bottleneck
- **US-002**: Show prompts flag - Add `--show-prompts` flag to display prompts in bottlenecks command
- **US-003**: Parse token usage - Extract input/output token counts from Claude transcript messages
- **US-004**: Cost command - Add `aist cost` with `--period` and `--detailed` flags
- **US-005**: Cost per PR/Issue - Show cost breakdown in `aist prs`, `aist issues`, and detail views

## New Commands

```bash
# Show bottlenecks with the prompts that triggered them
aist bottlenecks --show-prompts

# Show token usage and cost summary
aist cost
aist cost --period week
aist cost --detailed
```

## Technical Details

- Token pricing: Claude Opus 4.5 ($15/M input, $75/M output)
- Billable input = `input_tokens` + `cache_creation_input_tokens` (cache reads are free)
- Prompts truncated to 200 characters

## Test plan

- [x] `cargo fmt --check && cargo clippy && cargo test` passes
- [ ] Run `aist bottlenecks --show-prompts` and verify prompts appear
- [ ] Run `aist cost` and verify token/cost summary
- [ ] Run `aist prs` and verify cost column appears
- [ ] Run `aist issues` and verify cost column appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)